### PR TITLE
Remove remaining cl usage in favor of cl-lib

### DIFF
--- a/sr-speedbar.el
+++ b/sr-speedbar.el
@@ -264,8 +264,6 @@
 (require 'speedbar)
 (require 'advice)
 (require 'cl-lib)
-(eval-when-compile
-  (require 'cl))
 
 ;;; Code:
 
@@ -578,9 +576,9 @@ If WINDOW is nil, get current window."
     (walk-windows
      (lambda (w)
        (with-selected-window w
-         (incf window-number)
+         (cl-incf window-number)
          (if (window-dedicated-p w)
-             (incf dedicated-window-number)))))
+             (cl-incf dedicated-window-number)))))
     (if (and (> dedicated-window-number 0)
              (= (- window-number dedicated-window-number) 1))
         t nil)))


### PR DESCRIPTION
As of Emacs 27.1, the cl package has been officially deprecated in favor of cl-lib. This commit removes its remaining use.