### PR TITLE
Feature: split speedbar window from frame-root-window

### DIFF
--- a/sr-speedbar.el
+++ b/sr-speedbar.el
@@ -7,9 +7,9 @@
 ;; Copyright (C) 2008, 2009, Andy Stewart, all rights reserved.
 ;; Copyright (C) 2009, Peter Lunicks, all rights reversed.
 ;; Created: 2008
-;; Version: 20161025
+;; Version: 20200616
 ;; X-Original-Version: 0.1.10
-;; Last-Updated: 2016-10-25
+;; Last-Updated: 2020-06-16
 ;; URL: http://www.emacswiki.org/emacs/download/sr-speedbar.el
 ;; Keywords: speedbar, sr-speedbar.el
 ;; Compatibility: GNU Emacs 22 ~ GNU Emacs 25
@@ -78,6 +78,11 @@
 ;;      M-x customize-group RET sr-speedbar RET
 
 ;;; Change log:
+;; * 16 Jun 2020:
+;;   * Bo Yao <icerove@gmail.com> (submitted by him on 16 Jul 2018 to the Emacs Orphanage mirror version at GitHub)
+;;      * Always open file in most recently selected window (the one before switching to
+;;        sr-speedbar).
+;;
 ;; * 25 Oct 2016:
 ;;   * Hong Xu <hong@topbug.net>
 ;;      * Fix compilation warning when `helm-alive-p' is not defined.
@@ -520,19 +525,19 @@ Otherwise return nil."
 
 (defun sr-speedbar-before-visiting-file-hook ()
   "Function that hook `speedbar-before-visiting-file-hook'."
-  (select-window (previous-window)))
+  (select-window (get-mru-window)))
 
 (defun sr-speedbar-before-visiting-tag-hook ()
   "Function that hook `speedbar-before-visiting-tag-hook'."
-  (select-window (previous-window)))
+  (select-window (get-mru-window)))
 
 (defun sr-speedbar-visiting-file-hook ()
   "Function that hook `speedbar-visiting-file-hook'."
-  (select-window (previous-window)))
+  (select-window (get-mru-window)))
 
 (defun sr-speedbar-visiting-tag-hook ()
   "Function that hook `speedbar-visiting-tag-hook'."
-  (select-window (previous-window)))
+  (select-window (get-mru-window)))
 
 (defun sr-speedbar-kill-buffer-hook ()
   "Function that hook `kill-buffer-hook'."

--- a/sr-speedbar.el
+++ b/sr-speedbar.el
@@ -78,6 +78,10 @@
 ;;      M-x customize-group RET sr-speedbar RET
 
 ;;; Change log:
+;; * 07 Jan 2021:
+;;   * Jacob First <jacob.first@member.fsf.org>
+;;     * Fix inconsistent window selection when opening speedbar on the right side vs. on the left.
+;;
 ;; * 16 Jun 2020:
 ;;   * Bo Yao <icerove@gmail.com> (submitted by him on 16 Jul 2018 to the Emacs Orphanage mirror version at GitHub)
 ;;      * Always open file in most recently selected window (the one before switching to
@@ -507,21 +511,10 @@ Otherwise return nil."
 
 (defun sr-speedbar-get-window ()
   "Get `sr-speedbar' window."
-  (let ((current-window (selected-window))
-        ;; Get split new window.
-        (new-window (split-window
-                     (selected-window)
-                     (if sr-speedbar-right-side
-                         (- (sr-speedbar-current-window-take-width) sr-speedbar-width)
-                       sr-speedbar-width)
-                     t)))
-    ;; Select split window.
-    (setq sr-speedbar-window
-          (if sr-speedbar-right-side
-              ;; Select right window when `sr-speedbar-right-side' is enable.
-              new-window
-            ;; Otherwise select left widnow.
-            current-window))))
+  (setq sr-speedbar-window
+        (split-window (selected-window)
+                      (- sr-speedbar-width)
+                      (if sr-speedbar-right-side 'right 'left))))
 
 (defun sr-speedbar-before-visiting-file-hook ()
   "Function that hook `speedbar-before-visiting-file-hook'."

--- a/sr-speedbar.el
+++ b/sr-speedbar.el
@@ -78,6 +78,12 @@
 ;;      M-x customize-group RET sr-speedbar RET
 
 ;;; Change log:
+;; * 04 July 2022:
+;;   * Doerthous <doerthous@gmail.com>
+;;     * Add support that allows speedbar window split from `selected-window'
+;;       or `frame-root-window'.
+;;     * define `sr-speedbar-use-frame-root-window'.
+;;
 ;; * 22 Sep 2021:
 ;;   * Vasilij Schneidermann <mail@vasilij.de>
 ;;     * Fix cl deprecation warning
@@ -325,6 +331,16 @@ Default is nil."
   :type 'boolean
   :group 'sr-speedbar)
 
+(defcustom sr-speedbar-use-frame-root-window nil
+  "Open speedbar based on selected window or frame root window.
+If nil, the speedbar window will split from `selected-window'.
+Otherwise `frame-root-window'.
+Default is nil."
+  :type 'boolean
+  :set (lambda (symbol value)
+         (set symbol value))
+  :group 'sr-speedbar)
+
 (if (not (fboundp 'ad-advised-definition-p))
     (defun ad-advised-definition-p (definition)
       "Return non-nil if DEFINITION was generated from advice information."
@@ -514,7 +530,9 @@ Otherwise return nil."
 (defun sr-speedbar-get-window ()
   "Get `sr-speedbar' window."
   (setq sr-speedbar-window
-        (split-window (selected-window)
+        (split-window (if sr-speedbar-use-frame-root-window
+                          (frame-root-window)
+                        (selected-window))
                       (- sr-speedbar-width)
                       (if sr-speedbar-right-side 'right 'left))))
 

--- a/sr-speedbar.el
+++ b/sr-speedbar.el
@@ -7,16 +7,16 @@
 ;; Copyright (C) 2008, 2009, Andy Stewart, all rights reserved.
 ;; Copyright (C) 2009, Peter Lunicks, all rights reversed.
 ;; Created: 2008
-;; Version: 20200616
+;; Version: 20210922
 ;; X-Original-Version: 0.1.10
-;; Last-Updated: 2020-06-16
+;; Last-Updated: 2021-09-22
 ;; URL: http://www.emacswiki.org/emacs/download/sr-speedbar.el
 ;; Keywords: speedbar, sr-speedbar.el
 ;; Compatibility: GNU Emacs 22 ~ GNU Emacs 25
 ;;
 ;; Features required by this library:
 ;;
-;;  `speedbar' `advice' `cl'
+;;  `speedbar' `advice' `cl-lib'
 ;;
 
 ;;; This file is NOT part of GNU Emacs
@@ -78,6 +78,10 @@
 ;;      M-x customize-group RET sr-speedbar RET
 
 ;;; Change log:
+;; * 22 Sep 2021:
+;;   * Vasilij Schneidermann <mail@vasilij.de>
+;;     * Fix cl deprecation warning
+;;
 ;; * 07 Jan 2021:
 ;;   * Jacob First <jacob.first@member.fsf.org>
 ;;     * Fix inconsistent window selection when opening speedbar on the right side vs. on the left.
@@ -273,8 +277,6 @@
 (require 'speedbar)
 (require 'advice)
 (require 'cl-lib)
-(eval-when-compile
-  (require 'cl))
 
 ;;; Code:
 
@@ -576,9 +578,9 @@ If WINDOW is nil, get current window."
     (walk-windows
      (lambda (w)
        (with-selected-window w
-         (incf window-number)
+         (cl-incf window-number)
          (if (window-dedicated-p w)
-             (incf dedicated-window-number)))))
+             (cl-incf dedicated-window-number)))))
     (if (and (> dedicated-window-number 0)
              (= (- window-number dedicated-window-number) 1))
         t nil)))


### PR DESCRIPTION
1. Porting the recent changes made to sr-speedbar.el in emacswiki[1].
2.  Add support that allows speedbar window split from selected-window or frame-root-window.

  Initial window layout:
  ```
  --------------------------------
  |                              |
  |          Window 1            |
  |                              |
  |------------------------------|
  |                              |
  |          Window 2            |
  |                              |
  --------------------------------
  ```

  when speedbar window split from selected-window, we get this:

  ```
  --------------------------------
  |          |                   |
  | Speedbar |     Window 1      |
  |          |                   |
  |------------------------------|
  |                              |
  |          Window 2            |
  |                              |
  --------------------------------
  ```

  when speedbar window split from frame-root-window, we get this:

  ```
  --------------------------------
  |         |                    |
  |Speedbar |      Window 1      |
  |         |                    |
  |         |--------------------|
  |         |                    |
  |         |      Window 2      |
  |         |                    |
  --------------------------------
  ```

[1]: https://github.com/emacsmirror/emacswiki.org